### PR TITLE
better fix for cross-compile openmpi

### DIFF
--- a/recipe/build-kahip.sh
+++ b/recipe/build-kahip.sh
@@ -8,10 +8,9 @@
 set -e
 
 if [[ "${CONDA_BUILD_CROSS_COMPILATION:-0}" == "1" ]]; then
-  # add $PREFIX/lib to CXXFLAGS because $BUILD_PREFIX/lib
-  # gets added for cross-compiled openmpi. Not sure why!
-  export CXXFLAGS="${CXXFLAGS} -L${PREFIX}/lib"
-  export CMAKE_ARGS="--debug-output ${CMAKE_ARGS}"
+  # needed for cross-compile openmpi
+  export OPAL_CC="$CC"
+  export OPAL_PREFIX="$PREFIX"
 fi
 
 cmake \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   patches:
     - 0001-install-python-component.patch
 build:
-  number: 2
+  number: 3
   skip: true  # [win]
 
 outputs:


### PR DESCRIPTION
rather than trying to squeeze into -L priority, try to fix where the path is coming from.

should only affect mac-arm64 builds