### PR TITLE
ensure kahip-python includes mpi variant

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,6 +50,9 @@ outputs:
   - name: kahip-python
     build:
       script: bash ${RECIPE_DIR}/build-kahip-python.sh
+      # to preserve variants
+      force_use_keys:
+        - mpi
 
     requirements:
       build:


### PR DESCRIPTION
otherwise, we'll be missing some builds
